### PR TITLE
Fix: Promise reject 인자를 Error 객체로 래핑하여 전달하도록 수정

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,21 +11,15 @@ api.interceptors.response.use(
   (error) => {
     // 네트워크 또는 CORS 에러
     if (!error.response) {
-      return Promise.reject({
-        status: 'error',
-        data: null,
-        message: '네트워크 에러가 발생했습니다.',
-      });
+      return Promise.reject(new Error('네트워크 에러가 발생했습니다.'));
     }
 
     // 다른 서버 에러
-    const { status, data, message } = error.response.data;
+    const { message } = error.response.data;
 
-    return Promise.reject({
-      status: status || null,
-      data: data || null,
-      message: message || '알 수 없는 에러가 발생했습니다.',
-    });
+    return Promise.reject(
+      new Error(message || '알 수 없는 에러가 발생했습니다.'),
+    );
   },
 );
 


### PR DESCRIPTION
## 작업 개요
- prefer-promise-reject-errors 린트 규칙 준수하기 위해 Error 객체로 매핑

## 관련 이슈
#182 