### PR TITLE
feat: 채팅, 알림, 뱃지, 나의 활동 목록 대체 UI 추가

### DIFF
--- a/src/components/EmptyFallback.tsx
+++ b/src/components/EmptyFallback.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  message: string;
+}
+
+const EmptyFallback = ({ message }: Props) => {
+  return (
+    <div className="pt-16 text-center">
+      <p className="mb-4 whitespace-pre-line text-center text-gray-700">
+        {message}
+      </p>
+    </div>
+  );
+};
+
+export default EmptyFallback;

--- a/src/components/FallbackRender.tsx
+++ b/src/components/FallbackRender.tsx
@@ -1,0 +1,12 @@
+import { PropsWithChildren, ReactNode } from 'react';
+
+interface Props extends PropsWithChildren {
+  component?: ReactNode;
+  render?: boolean;
+}
+
+const FallbackRender = ({ component, render, children }: Props) => {
+  return <>{render ? component : children}</>;
+};
+
+export default FallbackRender;

--- a/src/containers/chat/ChatRoomList.tsx
+++ b/src/containers/chat/ChatRoomList.tsx
@@ -4,6 +4,8 @@ import { useGetChatRoomList } from '@/hooks/useChat';
 import Loading from '@/components/Loading';
 import ErrorFallback from '@/components/ErrorFallback';
 import ChatItem from './ChatItem';
+import FallbackRender from '@/components/FallbackRender';
+import EmptyFallback from '@/components/EmptyFallback';
 
 const ChatRoomList = () => {
   const {
@@ -30,14 +32,23 @@ const ChatRoomList = () => {
 
   return (
     <div className="flex w-full flex-col gap-3 px-8 py-4">
-      {chatRooms.map((chat) => (
-        <ChatItem
-          key={chat.chatRoomId}
-          chatRoomId={chat.chatRoomId}
-          gatherArticleSimpleInfo={chat.gatherArticleSimpleInfo}
-          latestChatMessageInfo={chat.latestChatMessageInfo}
-        />
-      ))}
+      <FallbackRender
+        render={chatRooms.length === 0}
+        component={
+          <EmptyFallback
+            message={`아직 참여한 채팅방이 없어요🙂\n관심 있는 모집글에 참가 신청해보세요!`}
+          />
+        }
+      >
+        {chatRooms.map((chat) => (
+          <ChatItem
+            key={chat.chatRoomId}
+            chatRoomId={chat.chatRoomId}
+            gatherArticleSimpleInfo={chat.gatherArticleSimpleInfo}
+            latestChatMessageInfo={chat.latestChatMessageInfo}
+          />
+        ))}
+      </FallbackRender>
     </div>
   );
 };

--- a/src/containers/my/MyArticle.tsx
+++ b/src/containers/my/MyArticle.tsx
@@ -6,6 +6,8 @@ import { Article as IArticle } from '@/types/article';
 import ErrorFallback from '@/components/ErrorFallback';
 import Article from '../home/Article';
 import useAppRouter from '@/hooks/custom/useAppRouter';
+import FallbackRender from '@/components/FallbackRender';
+import EmptyFallback from '@/components/EmptyFallback';
 
 const MyArticle = () => {
   const router = useAppRouter();
@@ -33,29 +35,34 @@ const MyArticle = () => {
   }
 
   return (
-    <div className="flex flex-col gap-y-4 pb-4">
-      {posts.map((article: IArticle) => (
-        <Article
-          onClick={() =>
-            router.push({
-              href: `/article/${article.id}`,
-              headerTitle: '모집글 상세',
-            })
-          }
-          key={article.id}
-          id={article.id}
-          title={article.title}
-          description={article.description}
-          meetingLocation={article.meetingLocation}
-          maxParticipants={article.maxParticipants}
-          currentParticipants={article.currentParticipants}
-          startDateTime={article.startDateTime}
-          endDateTime={article.endDateTime}
-          createdAt={article.createdAt}
-          status={article.status}
-        />
-      ))}
-    </div>
+    <FallbackRender
+      render={posts.length === 0}
+      component={<EmptyFallback message="작성한 모집글이 없어요🙂" />}
+    >
+      <div className="flex flex-col gap-y-4 pb-4">
+        {posts.map((article: IArticle) => (
+          <Article
+            onClick={() =>
+              router.push({
+                href: `/article/${article.id}`,
+                headerTitle: '모집글 상세',
+              })
+            }
+            key={article.id}
+            id={article.id}
+            title={article.title}
+            description={article.description}
+            meetingLocation={article.meetingLocation}
+            maxParticipants={article.maxParticipants}
+            currentParticipants={article.currentParticipants}
+            startDateTime={article.startDateTime}
+            endDateTime={article.endDateTime}
+            createdAt={article.createdAt}
+            status={article.status}
+          />
+        ))}
+      </div>
+    </FallbackRender>
   );
 };
 

--- a/src/containers/my/MyJoinedArticle.tsx
+++ b/src/containers/my/MyJoinedArticle.tsx
@@ -6,6 +6,8 @@ import { Article as IArticle } from '@/types/article';
 import ErrorFallback from '@/components/ErrorFallback';
 import Article from '../home/Article';
 import useAppRouter from '@/hooks/custom/useAppRouter';
+import FallbackRender from '@/components/FallbackRender';
+import EmptyFallback from '@/components/EmptyFallback';
 
 const MyJoinedArticle = () => {
   const router = useAppRouter();
@@ -32,29 +34,34 @@ const MyJoinedArticle = () => {
     );
   }
   return (
-    <div className="flex flex-col gap-y-4 pb-4">
-      {posts.map((article: IArticle) => (
-        <Article
-          onClick={() =>
-            router.push({
-              href: `/article/${article.id}`,
-              headerTitle: '모집글 상세',
-            })
-          }
-          key={article.id}
-          id={article.id}
-          title={article.title}
-          description={article.description}
-          meetingLocation={article.meetingLocation}
-          maxParticipants={article.maxParticipants}
-          currentParticipants={article.currentParticipants}
-          startDateTime={article.startDateTime}
-          endDateTime={article.endDateTime}
-          createdAt={article.createdAt}
-          status={article.status}
-        />
-      ))}
-    </div>
+    <FallbackRender
+      render={posts.length === 0}
+      component={<EmptyFallback message="참가한 모집글이 없어요🙂" />}
+    >
+      <div className="flex flex-col gap-y-4 pb-4">
+        {posts.map((article: IArticle) => (
+          <Article
+            onClick={() =>
+              router.push({
+                href: `/article/${article.id}`,
+                headerTitle: '모집글 상세',
+              })
+            }
+            key={article.id}
+            id={article.id}
+            title={article.title}
+            description={article.description}
+            meetingLocation={article.meetingLocation}
+            maxParticipants={article.maxParticipants}
+            currentParticipants={article.currentParticipants}
+            startDateTime={article.startDateTime}
+            endDateTime={article.endDateTime}
+            createdAt={article.createdAt}
+            status={article.status}
+          />
+        ))}
+      </div>
+    </FallbackRender>
   );
 };
 

--- a/src/containers/notifications/NotificationList.tsx
+++ b/src/containers/notifications/NotificationList.tsx
@@ -4,6 +4,8 @@ import { useGetNotificationList } from '@/hooks/useNotifications';
 import Loading from '@/components/Loading';
 import ErrorFallback from '@/components/ErrorFallback';
 import NotificationItem from './NotificationItem';
+import FallbackRender from '@/components/FallbackRender';
+import EmptyFallback from '@/components/EmptyFallback';
 
 const NotificationList = () => {
   const {
@@ -29,7 +31,10 @@ const NotificationList = () => {
   }
 
   return (
-    <>
+    <FallbackRender
+      render={notifications.length === 0}
+      component={<EmptyFallback message="모든 알림을 확인했어요🙂" />}
+    >
       {notifications.map((notification) => (
         <NotificationItem
           key={`${notification.message}-${notification.createdAt}`}
@@ -37,7 +42,7 @@ const NotificationList = () => {
           createdAt={notification.createdAt}
         />
       ))}
-    </>
+    </FallbackRender>
   );
 };
 

--- a/src/containers/profile/BadgeList.tsx
+++ b/src/containers/profile/BadgeList.tsx
@@ -35,7 +35,7 @@ const BadgeList = ({ badges, nickname }: Props) => {
       <div
         className={cn(
           'flex justify-center items-center space-x-10',
-          badges.length === 0 ? 'pb-4' : 'p-4',
+          badges.length === 0 ? 'pb-6' : 'p-4',
         )}
       >
         {badges.length === 0 && (

--- a/src/containers/profile/BadgeListDetail.tsx
+++ b/src/containers/profile/BadgeListDetail.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import ErrorFallback from '@/components/ErrorFallback';
+import FallbackRender from '@/components/FallbackRender';
 import Loading from '@/components/Loading';
 import { useUserInfo } from '@/hooks/custom/useUserInfo';
 import { useGetBadgeList } from '@/hooks/useProfile';
 import { UserInfo } from '@/types/user';
 import { cn } from '@/utils/tailwind';
 import Image from 'next/image';
+import EmptyFallback from '@/components/EmptyFallback';
 
 interface Props {
   nickname?: UserInfo['nickname'];
@@ -40,32 +42,39 @@ const BadgeListDetail = ({ nickname }: Props) => {
 
   return (
     <div className="px-4 py-8">
-      <div className={cn('grid grid-cols-3 gap-y-10 place-items-center')}>
-        {badges.length === 0 && (
-          <div className="text-sm text-gray-600">획득한 뱃지가 없습니다.</div>
-        )}
-        {badges.map(
-          (badge) =>
-            badge && (
-              <div key={badge.badgeYearMonth}>
-                <div className="flex size-24 items-center justify-center rounded-full bg-bgGray">
-                  <Image
-                    src={
-                      badge.badgeImageSignedURL || '/images/default_profile.png'
-                    }
-                    alt="badge image"
-                    width={65}
-                    height={65}
-                    className="bg-transparent"
-                  />
+      <FallbackRender
+        render={badges.length === 0}
+        component={
+          <EmptyFallback
+            message={`아직 획득한 뱃지가 없어요🥲\n다른 플레이어들과 함께 보드게임을 즐겨보세요!`}
+          />
+        }
+      >
+        <div className={cn('grid grid-cols-3 gap-y-10 place-items-center')}>
+          {badges.map(
+            (badge) =>
+              badge && (
+                <div key={badge.badgeYearMonth}>
+                  <div className="flex size-24 items-center justify-center rounded-full bg-bgGray">
+                    <Image
+                      src={
+                        badge.badgeImageSignedURL ||
+                        '/images/default_profile.png'
+                      }
+                      alt="badge image"
+                      width={65}
+                      height={65}
+                      className="bg-transparent"
+                    />
+                  </div>
+                  <div className="mt-2 text-center text-sm font-bold text-gray-600">
+                    {badge.badgeYearMonth}
+                  </div>
                 </div>
-                <div className="mt-2 text-center text-sm font-bold text-gray-600">
-                  {badge.badgeYearMonth}
-                </div>
-              </div>
-            ),
-        )}
-      </div>
+              ),
+          )}
+        </div>
+      </FallbackRender>
     </div>
   );
 };


### PR DESCRIPTION
## 작업 개요
채팅, 알림, 뱃지, 나의 활동 목록 대체 UI 추가

## 관련 이슈

close #223 

## 결과
<img width="469" height="935" alt="스크린샷 2025-08-08 220500" src="https://github.com/user-attachments/assets/5b51c25c-5666-4882-8e2f-d12bcce7b5a5" />

<img width="471" height="936" alt="스크린샷 2025-08-08 220426" src="https://github.com/user-attachments/assets/0399210c-44ce-422b-a229-7d2d8874ed63" />

<img width="469" height="938" alt="스크린샷 2025-08-08 215153" src="https://github.com/user-attachments/assets/87b03442-7dcf-4006-9872-34aa785810d1" />

<img width="472" height="937" alt="스크린샷 2025-08-08 220239" src="https://github.com/user-attachments/assets/0d664455-1ef1-4da0-800b-8ce753f55633" />

<img width="468" height="935" alt="스크린샷 2025-08-08 220216" src="https://github.com/user-attachments/assets/f293ae20-1f94-4632-b9c9-620f22c863b8" />

<img width="469" height="936" alt="스크린샷 2025-08-08 220205" src="https://github.com/user-attachments/assets/bcfbe152-946b-4778-a9f1-10c189fe8d71" />

